### PR TITLE
feat: add aircraft and fleet flight time tracking

### DIFF
--- a/PLAN-aircraft-flight-time.md
+++ b/PLAN-aircraft-flight-time.md
@@ -1,0 +1,182 @@
+# Feature: Total Flight Time Per Aircraft
+
+## Goal
+Display cumulative total flight time for each aircraft (drone), derived from the autopilot's `STAT_FLTTIME` counter extracted from uploaded DataFlash `.bin` logs. Also display fleet-wide total flight hours across all aircraft.
+
+## Design Rationale
+Not every flight log gets uploaded, so summing individual leg durations would undercount. Instead, we use the autopilot's own cumulative `STAT_FLTTIME` parameter, which tracks total flight time across the aircraft's entire lifetime. The **highest** `estimatedTotalFlightMinutesAfter` value across all logs for an aircraft represents the most up-to-date truth.
+
+We also store per-leg flight duration (`totalFlightSeconds`) for display on individual flight records.
+
+## Branch
+`feature/aircraft-flight-time`
+
+---
+
+## Changes
+
+### 1. Database Migration
+
+**New file:** `supabase/migrations/20260407231200_add_flight_time_columns.sql`
+
+```sql
+-- Per-leg: flight duration from this specific log (measured arm-to-disarm)
+ALTER TABLE public.flight_legs
+  ADD COLUMN flight_duration_sec double precision;
+
+-- Per-leg: cumulative total flight time reported by autopilot after this flight
+-- This is estimatedTotalFlightMinutesAfter from the parser (STAT_FLTTIME + this leg's duration)
+ALTER TABLE public.flight_legs
+  ADD COLUMN cumulative_flight_minutes double precision;
+
+-- View: get the max cumulative flight time per aircraft
+CREATE OR REPLACE VIEW public.aircraft_flight_totals AS
+SELECT
+  fl.aircraft_id,
+  MAX(fl.cumulative_flight_minutes) AS total_flight_minutes,
+  COUNT(fl.id) AS total_flight_legs
+FROM public.flight_legs fl
+WHERE fl.cumulative_flight_minutes IS NOT NULL
+GROUP BY fl.aircraft_id;
+
+-- View: total flight hours across ALL aircraft (fleet-wide)
+CREATE OR REPLACE VIEW public.fleet_flight_totals AS
+SELECT
+  COALESCE(SUM(aft.total_flight_minutes), 0) AS total_flight_minutes,
+  COUNT(aft.aircraft_id) AS aircraft_with_logs,
+  (SELECT COUNT(*) FROM public.aircraft) AS total_aircraft,
+  (SELECT COUNT(*) FROM public.flight_legs) AS total_flight_legs
+FROM public.aircraft_flight_totals aft;
+```
+
+### 2. Edge Function: Write flight time back on analysis
+
+**File:** `supabase/functions/mavlink-parser/index.ts`
+
+Modify the `handleLogTimeAnalysis` route (`POST /logs/:flightLegId/time/analysis`):
+
+- After running `getLogTimeAnalysis()`, take the **last** (most recent) result's `estimatedTotalFlightMinutesAfter` and `totalFlightSeconds`
+- Write these back to the `flight_legs` row:
+  ```ts
+  await supabaseAdmin
+    .from('flight_legs')
+    .update({
+      flight_duration_sec: lastResult.totalFlightSeconds,
+      cumulative_flight_minutes: lastResult.estimatedTotalFlightMinutesAfter,
+    })
+    .eq('id', flightLegId);
+  ```
+- Import `supabaseAdmin` from `../_shared/supabaseAdmin.ts` (already exists)
+- Only update if values are non-null (don't overwrite with undefined)
+- Continue returning the existing JSON response (non-breaking)
+
+### 3. Frontend API: Aircraft flight totals
+
+**New file:** `frontend/src/api/rest/aircraft_flight_totals.api.ts`
+
+```ts
+// Query the aircraft_flight_totals view
+export interface AircraftFlightTotal {
+  aircraftId: string;
+  totalFlightMinutes: number | null;
+  totalFlightLegs: number;
+}
+
+export async function getAircraftFlightTotals(): Promise<AircraftFlightTotal[]> {
+  // SELECT * FROM aircraft_flight_totals
+  const { data, error } = await supabase
+    .from('aircraft_flight_totals')
+    .select('*');
+  // Map snake_case → camelCase
+}
+
+export async function getAircraftFlightTotal(aircraftId: string): Promise<AircraftFlightTotal | null> {
+  const { data, error } = await supabase
+    .from('aircraft_flight_totals')
+    .select('*')
+    .eq('aircraft_id', aircraftId)
+    .maybeSingle();
+}
+```
+
+### 4. Frontend API: Fleet flight totals
+
+**New file:** `frontend/src/api/rest/fleet_flight_totals.api.ts`
+
+```ts
+export interface FleetFlightTotal {
+  totalFlightMinutes: number | null;
+  aircraftWithLogs: number;
+  totalAircraft: number;
+  totalFlightLegs: number;
+}
+
+export async function getFleetFlightTotals(): Promise<FleetFlightTotal | null> {
+  const { data, error } = await supabase
+    .from('fleet_flight_totals')
+    .select('*')
+    .single();
+}
+```
+
+### 5. Frontend: Aircraft List Page
+
+**File:** `frontend/src/views/aircraft/ListAircraftPage.vue`
+
+- On mount, also call `getAircraftFlightTotals()` to get a map of `aircraftId → totalMinutes`
+- Pass the flight time to each `AircraftCard`
+- Also fetch `getFleetFlightTotals()` on mount
+- Display a **fleet total banner/stat** at the top of the page: "Total Quiver Flight Time: XXh XXm across N aircraft"
+
+**File:** `frontend/src/components/aircraft/AircraftCard.vue`
+
+- Add optional `totalFlightMinutes` prop
+- Display formatted flight time (e.g. "12h 34m" or "—" if null) in the card body
+- Helper: `formatFlightTime(minutes: number | null): string`
+
+### 6. Frontend: Aircraft Detail Page
+
+**File:** `frontend/src/views/aircraft/AircraftPage.vue`
+
+- Fetch `getAircraftFlightTotal(aircraftId)` on mount
+- Display total flight time in the Details card (new row in the grid, alongside Name/Type/Serial/Owner)
+- Display total number of flight legs
+
+### 7. Frontend: Flight Leg Details
+
+**File:** `frontend/src/components/flight_legs/FlightLegDetailsSection.vue`
+
+- If `flight_duration_sec` is present on the leg data, show "Flight duration: Xm Ys" in the details grid
+- Requires adding `flightDurationSec` and `cumulativeFlightMinutes` to `FlightLegRow` / `FlightLegData` interfaces in `flight_legs.api.ts`
+
+### 8. Frontend: Flight Leg Card
+
+**File:** `frontend/src/components/flight_legs/FlightLegCard.vue`
+
+- Show flight duration badge if available
+
+---
+
+## File Summary
+
+| File | Action |
+|------|--------|
+| `supabase/migrations/20260407231200_add_flight_time_columns.sql` | **CREATE** — migration |
+| `supabase/functions/mavlink-parser/index.ts` | **MODIFY** — write flight time to DB after analysis |
+| `frontend/src/api/rest/aircraft_flight_totals.api.ts` | **CREATE** — new API module |
+| `frontend/src/api/rest/fleet_flight_totals.api.ts` | **CREATE** — new API module |
+| `frontend/src/api/rest/flight_legs.api.ts` | **MODIFY** — add new fields to interfaces + mapper |
+| `frontend/src/components/aircraft/AircraftCard.vue` | **MODIFY** — show flight time |
+| `frontend/src/views/aircraft/AircraftPage.vue` | **MODIFY** — fetch + show flight time |
+| `frontend/src/views/aircraft/ListAircraftPage.vue` | **MODIFY** — fetch totals, pass to cards |
+| `frontend/src/components/flight_legs/FlightLegDetailsSection.vue` | **MODIFY** — show per-leg duration |
+| `frontend/src/components/flight_legs/FlightLegCard.vue` | **MODIFY** — show duration badge |
+
+10 files total — 3 new, 7 modified.
+
+## Notes
+
+- The `aircraft_flight_totals` view uses RLS passthrough (views inherit the calling user's RLS context), so the broad SELECT policies already in place will work
+- If `STAT_FLTTIME` is not present in a log (older firmware), `estimatedTotalFlightMinutesAfter` will be null — that's fine, we just won't update
+- The edge function uses `supabaseAdmin` (service role) so the UPDATE bypasses RLS — this is intentional since it's server-side
+- The `fleet_flight_totals` view sums the per-aircraft MAX values (not individual legs) to avoid double-counting

--- a/frontend/src/api/rest/aircraft_flight_totals.api.ts
+++ b/frontend/src/api/rest/aircraft_flight_totals.api.ts
@@ -1,0 +1,68 @@
+// Stateless API for aircraft flight totals (read-only view)
+
+import { supabase } from '@/lib/supabaseClient'
+import { withErrorHandling, requireAuth } from '@/api/errorHandler'
+import { useAuthStore } from '@/features/auth/auth.store'
+
+const ENTITY_NAME = 'aircraft_flight_totals'
+
+// DB row (snake_case)
+interface AircraftFlightTotalRow {
+  aircraft_id: string
+  total_flight_minutes: number | null
+  total_flight_legs: number
+}
+
+// App-facing model (camelCase)
+export interface AircraftFlightTotal {
+  aircraftId: string
+  totalFlightMinutes: number | null
+  totalFlightLegs: number
+}
+
+function mapRowToData(row: AircraftFlightTotalRow): AircraftFlightTotal {
+  return {
+    aircraftId: row.aircraft_id,
+    totalFlightMinutes: row.total_flight_minutes,
+    totalFlightLegs: row.total_flight_legs,
+  }
+}
+
+// List all aircraft flight totals
+export async function getAircraftFlightTotals(): Promise<AircraftFlightTotal[]> {
+  const authStore = useAuthStore()
+  const operation = 'list aircraft flight totals'
+  requireAuth(authStore, operation)
+
+  const result = await withErrorHandling(async () => {
+    const { data, error } = await supabase
+      .from(ENTITY_NAME)
+      .select('*')
+
+    if (error) throw error
+    return (data as AircraftFlightTotalRow[]).map(mapRowToData)
+  }, { operation, entity: ENTITY_NAME, authStore })
+
+  return result ?? []
+}
+
+// Get flight total for a single aircraft
+export async function getAircraftFlightTotal(aircraftId: string): Promise<AircraftFlightTotal | null> {
+  const authStore = useAuthStore()
+  const operation = 'get aircraft flight total'
+  requireAuth(authStore, operation)
+
+  const result = await withErrorHandling(async () => {
+    const { data, error } = await supabase
+      .from(ENTITY_NAME)
+      .select('*')
+      .eq('aircraft_id', aircraftId)
+      .maybeSingle()
+
+    if (error) throw error
+    if (!data) return null
+    return mapRowToData(data as AircraftFlightTotalRow)
+  }, { operation, entity: ENTITY_NAME, authStore })
+
+  return result ?? null
+}

--- a/frontend/src/api/rest/fleet_flight_totals.api.ts
+++ b/frontend/src/api/rest/fleet_flight_totals.api.ts
@@ -1,0 +1,51 @@
+// Stateless API for fleet-wide flight totals (read-only view)
+
+import { supabase } from '@/lib/supabaseClient'
+import { withErrorHandling, requireAuth } from '@/api/errorHandler'
+import { useAuthStore } from '@/features/auth/auth.store'
+
+const ENTITY_NAME = 'fleet_flight_totals'
+
+// DB row (snake_case)
+interface FleetFlightTotalRow {
+  total_flight_minutes: number | null
+  aircraft_with_logs: number
+  total_aircraft: number
+  total_flight_legs: number
+}
+
+// App-facing model (camelCase)
+export interface FleetFlightTotal {
+  totalFlightMinutes: number | null
+  aircraftWithLogs: number
+  totalAircraft: number
+  totalFlightLegs: number
+}
+
+function mapRowToData(row: FleetFlightTotalRow): FleetFlightTotal {
+  return {
+    totalFlightMinutes: row.total_flight_minutes,
+    aircraftWithLogs: row.aircraft_with_logs,
+    totalAircraft: row.total_aircraft,
+    totalFlightLegs: row.total_flight_legs,
+  }
+}
+
+// Get fleet-wide flight totals
+export async function getFleetFlightTotals(): Promise<FleetFlightTotal | null> {
+  const authStore = useAuthStore()
+  const operation = 'get fleet flight totals'
+  requireAuth(authStore, operation)
+
+  const result = await withErrorHandling(async () => {
+    const { data, error } = await supabase
+      .from(ENTITY_NAME)
+      .select('*')
+      .single()
+
+    if (error) throw error
+    return mapRowToData(data as FleetFlightTotalRow)
+  }, { operation, entity: ENTITY_NAME, authStore })
+
+  return result ?? null
+}

--- a/frontend/src/api/rest/flight_legs.api.ts
+++ b/frontend/src/api/rest/flight_legs.api.ts
@@ -18,6 +18,8 @@ export interface FlightLegRow {
   temp_c: number | null
   title: string | null
   description: string | null
+  flight_duration_sec: number | null
+  cumulative_flight_minutes: number | null
   user_profiles?: { full_name: string } | null
 }
 
@@ -33,6 +35,8 @@ export interface FlightLegData {
   tempC: number | null
   title: string | null
   description: string | null
+  flightDurationSec: number | null
+  cumulativeFlightMinutes: number | null
   pilotName?: string | null
 }
 
@@ -66,6 +70,8 @@ function mapRowToData(row: FlightLegRow): FlightLegData {
     tempC: row.temp_c,
     title: row.title,
     description: row.description,
+    flightDurationSec: row.flight_duration_sec,
+    cumulativeFlightMinutes: row.cumulative_flight_minutes,
     pilotName: row.user_profiles?.full_name ?? null,
   }
 }

--- a/frontend/src/components/aircraft/AircraftCard.vue
+++ b/frontend/src/components/aircraft/AircraftCard.vue
@@ -6,6 +6,7 @@
                 <span class="badge badge-outline">{{ aircraft.aircraftType || '—' }}</span>
             </div>
             <p class="text-sm text-base-content/70">Serial: {{ aircraft.serialNumber }}</p>
+            <p v-if="totalFlightMinutes != null" class="text-sm font-medium">Flight time: {{ formatFlightTime(totalFlightMinutes) }}</p>
             <p v-if="aircraft.notes" class="text-sm line-clamp-2">{{ aircraft.notes }}</p>
             <div class="card-actions justify-end mt-2">
                 <slot name="actions"></slot>
@@ -17,7 +18,14 @@
 <script setup lang="ts">
 import type { AircraftData } from '@/api/rest/aircraft.api';
 
-defineProps<{ aircraft: AircraftData }>()
+defineProps<{ aircraft: AircraftData; totalFlightMinutes?: number | null }>()
+
+function formatFlightTime(minutes: number | null): string {
+    if (minutes == null) return '\u2014'
+    const h = Math.floor(minutes / 60)
+    const m = Math.round(minutes % 60)
+    return `${h}h ${m}m`
+}
 </script>
 
 <style scoped></style>

--- a/frontend/src/components/flight_legs/FlightLegCard.vue
+++ b/frontend/src/components/flight_legs/FlightLegCard.vue
@@ -8,6 +8,7 @@
                     <div class="flex items-center gap-2">
                         <h3 class="card-title text-base">{{ leg.title || 'Flight leg' }}</h3>
                         <span v-if="leg.location" class="badge badge-outline">{{ leg.location }}</span>
+                        <span v-if="leg.flightDurationSec != null" class="badge badge-primary badge-outline">{{ formatDuration(leg.flightDurationSec) }}</span>
                     </div>
                     <div class="text-xs text-base-content/70">
                         <span>Created: {{ formatDate(leg.createdAt) }}</span>
@@ -35,6 +36,12 @@ defineProps<{ leg: FlightLegData }>()
 
 function formatDate(iso: string): string {
     try { return new Date(iso).toLocaleString() } catch { return iso }
+}
+
+function formatDuration(seconds: number): string {
+    const m = Math.floor(seconds / 60)
+    const s = Math.round(seconds % 60)
+    return `${m}m ${s}s`
 }
 </script>
 

--- a/frontend/src/components/flight_legs/FlightLegDetailsSection.vue
+++ b/frontend/src/components/flight_legs/FlightLegDetailsSection.vue
@@ -42,6 +42,10 @@
                         <div class="text-sm text-base-content/70">Temperature (°C)</div>
                         <div>{{ leg.tempC ?? '—' }}</div>
                     </div>
+                    <div v-if="leg.flightDurationSec != null">
+                        <div class="text-sm text-base-content/70">Flight duration</div>
+                        <div>{{ formatDuration(leg.flightDurationSec) }}</div>
+                    </div>
                 </div>
                 <div>
                     <div class="text-sm text-base-content/70">Description</div>
@@ -138,6 +142,12 @@ const aircraftError = ref('')
 
 function formatDate(iso: string): string {
     try { return new Date(iso).toLocaleString() } catch { return iso }
+}
+
+function formatDuration(seconds: number): string {
+    const m = Math.floor(seconds / 60)
+    const s = Math.round(seconds % 60)
+    return `${m}m ${s}s`
 }
 
 async function load() {

--- a/frontend/src/views/aircraft/AircraftPage.vue
+++ b/frontend/src/views/aircraft/AircraftPage.vue
@@ -46,6 +46,14 @@
 								<div class="text-sm text-base-content/70">Owner</div>
 								<div class="truncate">{{ aircraft.ownerId || '—' }}</div>
 							</div>
+							<div>
+								<div class="text-sm text-base-content/70">Total flight time</div>
+								<div>{{ formatFlightTime(flightTotal?.totalFlightMinutes ?? null) }}</div>
+							</div>
+							<div>
+								<div class="text-sm text-base-content/70">Flight legs</div>
+								<div>{{ flightTotal?.totalFlightLegs ?? '—' }}</div>
+							</div>
 						</div>
 						<div>
 							<div class="text-sm text-base-content/70">Notes</div>
@@ -124,6 +132,7 @@ import { onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type { AircraftData, UpdateAircraftInput } from '@/api/rest/aircraft.api'
 import { getAircraft, updateAircraft, deleteAircraft } from '@/api/rest/aircraft.api'
+import { getAircraftFlightTotal, type AircraftFlightTotal } from '@/api/rest/aircraft_flight_totals.api'
 import MaintenanceLogsSection from '@/components/aircraft_maintenance/MaintenanceLogsSection.vue';
 
 const route = useRoute()
@@ -139,6 +148,7 @@ const success = ref('')
 
 const form = ref<UpdateAircraftInput>({})
 const deleteDialogRef = ref<HTMLDialogElement | null>(null)
+const flightTotal = ref<AircraftFlightTotal | null>(null)
 
 function formatDate(iso: string): string {
 	try {
@@ -148,6 +158,13 @@ function formatDate(iso: string): string {
 	}
 }
 
+function formatFlightTime(minutes: number | null): string {
+	if (minutes == null) return '\u2014'
+	const h = Math.floor(minutes / 60)
+	const m = Math.round(minutes % 60)
+	return `${h}h ${m}m`
+}
+
 async function load() {
 	try {
 		error.value = ''
@@ -155,6 +172,8 @@ async function load() {
 		const id = route.params.id as string
 		const data = await getAircraft(id)
 		aircraft.value = data
+		// Fetch flight totals (non-blocking)
+		getAircraftFlightTotal(id).then(t => { flightTotal.value = t }).catch(() => {})
 	} catch (e: any) {
 		error.value = e?.message || 'Failed to load aircraft'
 	} finally {

--- a/frontend/src/views/aircraft/ListAircraftPage.vue
+++ b/frontend/src/views/aircraft/ListAircraftPage.vue
@@ -1,6 +1,19 @@
 <template>
 	<section class="max-w-6xl mx-auto px-6 py-8">
 
+		<!-- Fleet Stats Banner -->
+		<div v-if="fleetTotals" class="stats shadow mb-6 w-full">
+			<div class="stat">
+				<div class="stat-title">Total Fleet Flight Time</div>
+				<div class="stat-value text-primary">{{ formatFlightTime(fleetTotals.totalFlightMinutes) }}</div>
+				<div class="stat-desc">across {{ fleetTotals.aircraftWithLogs }} of {{ fleetTotals.totalAircraft }} aircraft</div>
+			</div>
+			<div class="stat">
+				<div class="stat-title">Total Flight Legs</div>
+				<div class="stat-value">{{ fleetTotals.totalFlightLegs }}</div>
+			</div>
+		</div>
+
         <!-- Aircraft List Header -->
 		<div class="flex items-end justify-between mb-6">
 			<div>
@@ -22,7 +35,7 @@
 
             <!-- Aircraft List -->
 			<template v-for="ac in aircraft" :key="ac.id">
-				<AircraftCard :aircraft="ac">
+				<AircraftCard :aircraft="ac" :total-flight-minutes="flightTotalsMap[ac.id] ?? null">
 					<template #actions>
 						<RouterLink class="btn btn-ghost btn-sm" :to="{ name: 'Aircraft', params: { id: ac.id } }">Open</RouterLink>
 					</template>
@@ -35,8 +48,10 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { onMounted, ref, reactive } from 'vue'
 import { listAircraft, type AircraftData } from '@/api/rest/aircraft.api'
+import { getAircraftFlightTotals } from '@/api/rest/aircraft_flight_totals.api'
+import { getFleetFlightTotals, type FleetFlightTotal } from '@/api/rest/fleet_flight_totals.api'
 import CreateAircraftCard from '@/components/aircraft/CreateAircraftCard.vue'
 import AircraftCard from '@/components/aircraft/AircraftCard.vue'
 import CreateAircraftModal from '@/components/aircraft/CreateAircraftModal.vue'
@@ -44,6 +59,15 @@ import CreateAircraftModal from '@/components/aircraft/CreateAircraftModal.vue'
 const aircraft = ref<AircraftData[]>([])
 const error = ref('')
 const createModalRef = ref<InstanceType<typeof CreateAircraftModal> | null>(null)
+const flightTotalsMap = reactive<Record<string, number | null>>({})
+const fleetTotals = ref<FleetFlightTotal | null>(null)
+
+function formatFlightTime(minutes: number | null): string {
+	if (minutes == null) return '\u2014'
+	const h = Math.floor(minutes / 60)
+	const m = Math.round(minutes % 60)
+	return `${h}h ${m}m`
+}
 
 async function fetchAircraft() {
 	try {
@@ -52,6 +76,21 @@ async function fetchAircraft() {
 	} catch (e: any) {
 		error.value = e?.message || 'Failed to load aircraft'
 	}
+}
+
+async function fetchFlightTotals() {
+	try {
+		const totals = await getAircraftFlightTotals()
+		for (const t of totals) {
+			flightTotalsMap[t.aircraftId] = t.totalFlightMinutes
+		}
+	} catch { /* non-critical */ }
+}
+
+async function fetchFleetTotals() {
+	try {
+		fleetTotals.value = await getFleetFlightTotals()
+	} catch { /* non-critical */ }
 }
 
 function openCreateModal() {
@@ -63,7 +102,11 @@ async function handleCreated(newAircraft: AircraftData) {
 	aircraft.value = [newAircraft, ...aircraft.value]
 }
 
-onMounted(fetchAircraft)
+onMounted(() => {
+	fetchAircraft()
+	fetchFlightTotals()
+	fetchFleetTotals()
+})
 </script>
 
 <style scoped></style>

--- a/scripts/backfill-flight-times.ts
+++ b/scripts/backfill-flight-times.ts
@@ -1,0 +1,153 @@
+/**
+ * Backfill flight_duration_sec and cumulative_flight_minutes for all flight legs
+ * that have uploaded logs but are missing flight time data.
+ *
+ * Usage:
+ *   SUPABASE_URL=https://xxx.supabase.co SUPABASE_SERVICE_KEY=xxx npx tsx scripts/backfill-flight-times.ts
+ *
+ * Environment variables (required):
+ *   SUPABASE_URL           — Project URL (e.g. https://<ref>.supabase.co)
+ *   SUPABASE_SERVICE_KEY   — Service-role key (bypasses RLS)
+ *
+ * Optional:
+ *   DRY_RUN=true           — List legs that would be processed without calling the edge function
+ *   CONCURRENCY=3          — Max parallel requests (default 3)
+ */
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
+const DRY_RUN = process.env.DRY_RUN === "true";
+const CONCURRENCY = parseInt(process.env.CONCURRENCY ?? "3", 10);
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  console.error(
+    "Missing required env vars: SUPABASE_URL, SUPABASE_SERVICE_KEY"
+  );
+  process.exit(1);
+}
+
+const headers = {
+  apikey: SUPABASE_SERVICE_KEY,
+  Authorization: `Bearer ${SUPABASE_SERVICE_KEY}`,
+  "Content-Type": "application/json",
+};
+
+interface FlightLegToBackfill {
+  id: string;
+  aircraft_id: string;
+}
+
+async function getLegsToBackfill(): Promise<FlightLegToBackfill[]> {
+  // Get flight legs missing flight time data
+  const url = `${SUPABASE_URL}/rest/v1/flight_legs?select=id,aircraft_id&cumulative_flight_minutes=is.null`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    console.error("Failed to fetch flight legs:", await res.text());
+    process.exit(1);
+  }
+  const allLegs: FlightLegToBackfill[] = await res.json();
+
+  // Get flight legs that have logs
+  const logUrl = `${SUPABASE_URL}/rest/v1/flight_leg_logs?select=flight_leg_id`;
+  const logRes = await fetch(logUrl, { headers });
+  if (!logRes.ok) {
+    console.error("Failed to fetch flight leg logs:", await logRes.text());
+    process.exit(1);
+  }
+  const logRows: { flight_leg_id: string }[] = await logRes.json();
+  const legIdsWithLogs = new Set(logRows.map((r) => r.flight_leg_id));
+
+  // Only backfill legs that have logs
+  return allLegs.filter((leg) => legIdsWithLogs.has(leg.id));
+}
+
+async function analyzeFlightTime(
+  legId: string
+): Promise<{ ok: boolean; note?: string }> {
+  const url = `${SUPABASE_URL}/functions/v1/mavlink-parser/logs/${legId}/time/analysis`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    return { ok: false, note: `HTTP ${res.status}: ${body}` };
+  }
+
+  const data = await res.json();
+  const analyses = data?.timeAnalyses ?? [];
+  if (analyses.length === 0) {
+    return { ok: true, note: "no time data in log" };
+  }
+
+  const last = analyses[analyses.length - 1];
+  if (last.estimatedTotalFlightMinutesAfter == null) {
+    return { ok: true, note: "STAT_FLTTIME not found in log" };
+  }
+
+  return { ok: true };
+}
+
+async function runBatch<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<void>
+): Promise<void> {
+  let current = 0;
+  const workers = Array.from({ length: concurrency }, async () => {
+    while (current < items.length) {
+      const index = current++;
+      await fn(items[index], index);
+    }
+  });
+  await Promise.all(workers);
+}
+
+async function main() {
+  console.log(`Supabase URL: ${SUPABASE_URL}`);
+  console.log(`Dry run: ${DRY_RUN}`);
+  console.log(`Concurrency: ${CONCURRENCY}\n`);
+
+  const legs = await getLegsToBackfill();
+  console.log(`Found ${legs.length} flight legs to backfill\n`);
+
+  if (legs.length === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+
+  if (DRY_RUN) {
+    for (const leg of legs) {
+      console.log(`  [dry-run] ${leg.id} (aircraft: ${leg.aircraft_id})`);
+    }
+    console.log(`\nRe-run without DRY_RUN=true to process.`);
+    return;
+  }
+
+  let success = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  await runBatch(legs, CONCURRENCY, async (leg, i) => {
+    const prefix = `[${i + 1}/${legs.length}]`;
+    const result = await analyzeFlightTime(leg.id);
+
+    if (!result.ok) {
+      console.log(`  ${prefix} FAIL  ${leg.id} — ${result.note}`);
+      failed++;
+    } else if (result.note) {
+      console.log(`  ${prefix} SKIP  ${leg.id} — ${result.note}`);
+      skipped++;
+    } else {
+      console.log(`  ${prefix} OK    ${leg.id}`);
+      success++;
+    }
+  });
+
+  console.log(
+    `\nDone: ${success} updated, ${skipped} skipped, ${failed} failed`
+  );
+}
+
+main();

--- a/supabase/functions/mavlink-parser/index.ts
+++ b/supabase/functions/mavlink-parser/index.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import { functionCORS } from "../_shared/cors.ts";
 import { listFlightLegLogs, type FlightLogHandle } from "storage";
 
+import { supabaseAdmin } from "../_shared/supabaseAdmin.ts";
 import { getLogParamsDiff } from "./df-analysis/params.ts";
 import { getLogTimeAnalysis } from "./df-analysis/flight-time.ts";
 
@@ -118,6 +119,25 @@ async function handleLogTimeAnalysis(c: Context): Promise<Response> {
 
     // 2) Analyze the log time
     const timeAnalyses = await getLogTimeAnalysis(logs, {});
+
+    // 3) Write flight time back to the flight_legs row
+    if (timeAnalyses.length > 0) {
+      const lastResult = timeAnalyses[timeAnalyses.length - 1];
+      const updatePayload: Record<string, number> = {};
+      if (lastResult.totalFlightSeconds != null) {
+        updatePayload.flight_duration_sec = lastResult.totalFlightSeconds;
+      }
+      if (lastResult.estimatedTotalFlightMinutesAfter != null) {
+        updatePayload.cumulative_flight_minutes = lastResult.estimatedTotalFlightMinutesAfter;
+      }
+      if (Object.keys(updatePayload).length > 0) {
+        await supabaseAdmin
+          .from('flight_legs')
+          .update(updatePayload)
+          .eq('id', flightLegId);
+      }
+    }
+
     return c.json({ flightLegId, timeAnalyses });
   } catch (err) {
     console.error(err);

--- a/supabase/migrations/20260407231200_add_flight_time_columns.sql
+++ b/supabase/migrations/20260407231200_add_flight_time_columns.sql
@@ -1,0 +1,27 @@
+-- Per-leg: flight duration from this specific log (measured arm-to-disarm)
+ALTER TABLE public.flight_legs
+  ADD COLUMN flight_duration_sec double precision;
+
+-- Per-leg: cumulative total flight time reported by autopilot after this flight
+-- This is estimatedTotalFlightMinutesAfter from the parser (STAT_FLTTIME + this leg's duration)
+ALTER TABLE public.flight_legs
+  ADD COLUMN cumulative_flight_minutes double precision;
+
+-- View: get the max cumulative flight time per aircraft
+CREATE OR REPLACE VIEW public.aircraft_flight_totals AS
+SELECT
+  fl.aircraft_id,
+  MAX(fl.cumulative_flight_minutes) AS total_flight_minutes,
+  COUNT(fl.id) AS total_flight_legs
+FROM public.flight_legs fl
+WHERE fl.cumulative_flight_minutes IS NOT NULL
+GROUP BY fl.aircraft_id;
+
+-- View: total flight hours across ALL aircraft (fleet-wide)
+CREATE OR REPLACE VIEW public.fleet_flight_totals AS
+SELECT
+  COALESCE(SUM(aft.total_flight_minutes), 0) AS total_flight_minutes,
+  COUNT(aft.aircraft_id) AS aircraft_with_logs,
+  (SELECT COUNT(*) FROM public.aircraft) AS total_aircraft,
+  (SELECT COUNT(*) FROM public.flight_legs) AS total_flight_legs
+FROM public.aircraft_flight_totals aft;


### PR DESCRIPTION
## Summary
- Adds `flight_duration_sec` and `cumulative_flight_minutes` columns to `flight_legs` table, with DB views for per-aircraft and fleet-wide aggregation
- Updates the mavlink-parser edge function to write STAT_FLTTIME data back to `flight_legs` after log analysis
- Adds fleet flight time banner on the aircraft list page and per-aircraft totals on detail pages
- Shows per-leg flight duration on flight leg cards and detail sections

## Data strategy
Uses the autopilot's cumulative `STAT_FLTTIME` counter (not summed leg durations) so that missing uploads don't undercount. The `aircraft_flight_totals` view takes `MAX(cumulative_flight_minutes)` per aircraft.

## Before merge
- [ ] Run time analysis backfill against existing flight legs to populate real STAT_FLTTIME data
- [ ] Verify flight times display correctly in preview environment

## Test plan
- [ ] Verify Supabase preview branch creates migration and deploys edge function
- [ ] Trigger `POST /logs/:flightLegId/time/analysis` for flight legs with logs
- [ ] Confirm fleet banner shows correct totals on aircraft list page
- [ ] Confirm per-aircraft totals on aircraft detail page
- [ ] Confirm per-leg duration on flight leg cards/details

🤖 Generated with [Claude Code](https://claude.com/claude-code)